### PR TITLE
Remove duplicate contents

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -71,7 +71,6 @@ var pages = []page{
 	{"Function hooks", "hooks.md"},
 	{"Viewing log output", "logs.md"},
 	{"Viewing metrics", "metrics.md"},
-	{"Viewing build output", "build.md"},
 	{"Previewing with dry-run", "dryrun.md"},
 	{"Environment variables", "env.md"},
 	{"Omitting files", "ignore.md"},

--- a/index.html
+++ b/index.html
@@ -53,8 +53,6 @@
           
             <li><a href="#viewing-metrics">Viewing metrics</a></li>
           
-            <li><a href="#viewing-build-output">Viewing build output</a></li>
-          
             <li><a href="#previewing-with-dry-run">Previewing with dry-run</a></li>
           
             <li><a href="#environment-variables">Environment variables</a></li>
@@ -577,17 +575,6 @@ lowercase
   throttles: 0
   error: 5
 
-</code></pre>
-
-    
-      <h1 id="viewing-build-output">Viewing build output</h1>
-      <p>Apex generates a zip file for you upon deploy, however sometimes it can be useful to see exactly what&rsquo;s included in this file for debugging purposes. The <code>apex build</code> command outputs the zip to STDOUT for this purpose.</p>
-
-<h2 id="examples">Examples</h2>
-
-<p>Output zip to out.zip:</p>
-
-<pre><code class="language-sh">$ apex build foo &gt; out.zip
 </code></pre>
 
     


### PR DESCRIPTION
The "Viewing build output" section has the same content of "Building functions", maybe this has been done on purpose, but I found it odd to read the same thing twice.

I think that keeping only the "Building functions" section is sufficient, my brain tells me to look there if I want info about the build output.

I understand that this is subjective, so feel free to ignore and close this pr.
