### PR TITLE
added windows scoop installation instruction

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,10 @@ alternatively chown <code>/usr/local</code>:</p>
 <pre><code>curl https://raw.githubusercontent.com/apex/apex/master/install.sh | sh
 </code></pre>
 
-<p>On Windows download <a href="https://github.com/apex/apex/releases">binary</a>.</p>
+<p>On Windows download <a href="https://github.com/apex/apex/releases">binary</a> or use <a href="http://scoop.sh/">scoop</a>:</p>
+
+<pre><code>scoop install apex
+</code></pre>
 
 <p>If already installed, upgrade with:</p>
 


### PR DESCRIPTION
Windows devs may find this a handy alternative to downloading binaries. Related PR here https://github.com/lukesampson/scoop/pull/992
